### PR TITLE
Fix incorrect generateTitle title value & add screenshot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,5 +115,6 @@ export default config;
   ```
 
   ## Screenshots
+  ![image](https://user-images.githubusercontent.com/70709113/163850633-f3da5f8e-2527-4688-bc79-17233307a883.png)
 
   <!-- ![screenshot 1](https://github.com/trouble/payload-plugin-seo/blob/main/images/screenshot-1.jpg?raw=true) -->

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const config = buildConfig({
         'pages',
       ],
       uploadsCollection: 'media',
-      generateTitle: ({ doc }) => `Website.com — ${doc.title}`,
+      generateTitle: ({ doc }) => `Website.com — ${doc.title.value}`,
       generateDescription: ({ doc }) => doc.excerpt
     })
   ]


### PR DESCRIPTION
doc.title only returns an object:
![image](https://user-images.githubusercontent.com/70709113/163850162-21bbb86a-594f-4a7f-afee-7487a00c3c65.png)

doc.title.value would return the title as a string